### PR TITLE
workaround for copying files across filesystems

### DIFF
--- a/src/tiled/BuildingEditor/buildingwriter.cpp
+++ b/src/tiled/BuildingEditor/buildingwriter.cpp
@@ -523,7 +523,7 @@ bool BuildingWriter::write(Building *building, const QString &filePath)
 
     // /tmp/tempXYZ -> foo.tbx
     tempFile.close();
-    if (!tempFile.rename(filePath)) {
+    if (!tempFile.copy(filePath)) {
         d->mError = QString(QLatin1String("Error renaming file!\nFrom: %1\nTo: %2\n\n%3"))
                 .arg(tempFile.fileName())
                 .arg(filePath)

--- a/src/tiled/BuildingEditor/simplefile.cpp
+++ b/src/tiled/BuildingEditor/simplefile.cpp
@@ -99,7 +99,7 @@ bool SimpleFile::write(const QString &filePath)
 
     // /tmp/tempXYZ -> foo.txt
     tempFile.close();
-    if (!tempFile.rename(filePath)) {
+    if (!tempFile.copy(filePath)) {
         mError = QString(QLatin1String("Error renaming file!\nFrom: %1\nTo: %2\n\n%3"))
                 .arg(tempFile.fileName())
                 .arg(filePath)

--- a/src/tiled/containeroverlayfile.cpp
+++ b/src/tiled/containeroverlayfile.cpp
@@ -365,7 +365,7 @@ bool ContainerOverlayFile::write(const QString &filePath, const QList<ContainerO
 
     // /tmp/tempXYZ -> foo.tbx
     tempFile.close();
-    if (!tempFile.rename(filePath)) {
+    if (!tempFile.copy(filePath)) {
         mError = QString(QLatin1String("Error renaming file!\nFrom: %1\nTo: %2\n\n%3"))
                 .arg(tempFile.fileName())
                 .arg(filePath)

--- a/src/tiled/luamapsdialog.cpp
+++ b/src/tiled/luamapsdialog.cpp
@@ -169,7 +169,7 @@ bool LuaMapsDialog::processMap(const QString &mapFilePath)
     }
 
     // /tmp/tempXYZ -> foo.tmx
-    if (!tempFile.rename(mapFilePath)) {
+    if (!tempFile.copy(mapFilePath)) {
         backup.rename(mapFilePath);
         QString msg = QString(QLatin1String("Error renaming file!\nFrom: %1\nTo: %2"))
                 .arg(QFileInfo(tempFile).fileName())

--- a/src/tiled/tileoverlayfile.cpp
+++ b/src/tiled/tileoverlayfile.cpp
@@ -352,7 +352,7 @@ bool TileOverlayFile::write(const QString &filePath, const QList<TileOverlay*> &
 
     // /tmp/tempXYZ -> foo.tbx
     tempFile.close();
-    if (!tempFile.rename(filePath)) {
+    if (!tempFile.copy(filePath)) {
         mError = QString(QLatin1String("Error renaming file!\nFrom: %1\nTo: %2\n\n%3"))
                 .arg(tempFile.fileName())
                 .arg(filePath)


### PR DESCRIPTION
issue reported by Faalagorn here https://theindiestone.com/forums/index.php?/topic/35239-latest-tilezed-worlded-and-tilesets-april-7-2021/

The rename() function fails when copying across filesystem boundaries, such as from /tmp to /home when they are different partitions. This changes rename() to copy() when working with temporary files. This does not change any expected behavior because QT temporary files already remove themselves unless told not to.