### PR TITLE
Mention qt5-tools for Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Make sure the Qt (>= 4.6) development libraries are installed:
 
 * In Ubuntu/Debian: `sudo apt-get install libqt4-dev libqt4-opengl-dev zlib1g-dev`
 * In Fedora:        `yum install qt-devel`
-* In Arch Linux:    `pacman -S qt`
+* In Arch Linux:    `pacman -S qt qt5-tools`
 
 Now you can compile by running:
 


### PR DESCRIPTION
qt5-tools is required dependency to successfully build the project