### PR TITLE
Zlib add include for <unistd.h> for linux/unix compilation

### DIFF
--- a/src/zlib/gzlib.c
+++ b/src/zlib/gzlib.c
@@ -5,6 +5,10 @@
 
 #include "gzguts.h"
 
+#ifndef _WIN32
+#  include <unistd.h>
+#endif
+
 #if defined(_WIN32) && !defined(__BORLANDC__)
 #  define LSEEK _lseeki64
 #else

--- a/src/zlib/gzread.c
+++ b/src/zlib/gzread.c
@@ -5,6 +5,10 @@
 
 #include "gzguts.h"
 
+#ifndef _WIN32
+#  include <unistd.h>
+#endif
+
 /* Local functions */
 local int gz_load OF((gz_statep, unsigned char *, unsigned, unsigned *));
 local int gz_avail OF((gz_statep));

--- a/src/zlib/gzwrite.c
+++ b/src/zlib/gzwrite.c
@@ -5,6 +5,10 @@
 
 #include "gzguts.h"
 
+#ifndef _WIN32
+#  include <unistd.h>
+#endif
+
 /* Local functions */
 local int gz_init OF((gz_statep));
 local int gz_comp OF((gz_statep, int));


### PR DESCRIPTION
Added include for <unistd.h> in gzlib.c gzwrite.c and gzread.c.

This small tweak is needed to compile on linux and should not affect builds for _WIN32.

FIXES:  #7 